### PR TITLE
Add code_exec tool for RLM capabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,6 +82,12 @@
     "vitest": "^3.0.0"
   },
   "packageManager": "pnpm@10.0.0",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "sqlite3",
+      "esbuild"
+    ]
+  },
   "engines": {
     "node": ">=22.0.0"
   },

--- a/scripts/rlm_demonstration.ts
+++ b/scripts/rlm_demonstration.ts
@@ -1,0 +1,196 @@
+
+import { VoltClawAgent } from '../src/core/agent.js';
+import { MockLLM } from '../src/testing/mock-llm.js';
+import { FileStore } from '../src/memory/index.js';
+import { createAllTools } from '../src/tools/index.js';
+import { Channel, MessageHandler, Unsubscribe } from '../src/core/types.js';
+import fs from 'fs';
+import path from 'path';
+
+// --- Mocks ---
+
+class MockChannel implements Channel {
+    readonly type = 'mock';
+    readonly identity = { publicKey: 'mock-pubkey' };
+    private handlers: MessageHandler[] = [];
+
+    async start() {}
+    async stop() {}
+    async send(to: string, content: string) {
+        // Echo back to self for subtasks
+        if (to === this.identity.publicKey) {
+             const meta = { timestamp: Date.now() };
+             // Use setTimeout to allow I/O breathing room
+             setTimeout(() => {
+                 for (const h of this.handlers) h(to, content, meta);
+             }, 10);
+        }
+    }
+    subscribe(handler: MessageHandler): Unsubscribe {
+        this.handlers.push(handler);
+        return () => {};
+    }
+    on() {}
+}
+
+async function runDemo() {
+    console.log("=== VoltClaw RLM Demo ===");
+
+    const tools = await createAllTools();
+    const storePath = path.join(process.cwd(), 'demo_data.json');
+    if (fs.existsSync(storePath)) fs.unlinkSync(storePath);
+
+    // --- Test 1: Persistence ---
+    console.log("\n--- Test 1: Persistent REPL State ---");
+
+    let step1 = 0;
+    const llm1 = new MockLLM({
+        handler: async (messages) => {
+            const last = messages[messages.length - 1];
+
+            if (last.role === 'user' && last.content?.includes('Load the number 42')) {
+                step1 = 1;
+                return {
+                    content: "Step 1",
+                    toolCalls: [{
+                        id: 'call1',
+                        name: 'code_exec',
+                        arguments: {
+                            code: 'var magicNumber = 42; "set";',
+                            sessionId: 'test-session-1'
+                        }
+                    }]
+                };
+            }
+
+            if (last.role === 'tool' && step1 === 1) {
+                step1 = 2;
+                return {
+                    content: "Step 2",
+                    toolCalls: [{
+                        id: 'call2',
+                        name: 'code_exec',
+                        arguments: {
+                            code: 'var result = magicNumber * 10; result;',
+                            sessionId: 'test-session-1'
+                        }
+                    }]
+                };
+            }
+
+            if (last.role === 'tool' && step1 === 2) {
+                step1 = 3;
+                return {
+                    content: "Step 3",
+                    toolCalls: [{
+                        id: 'call3',
+                        name: 'code_exec',
+                        arguments: {
+                            code: '({ magic: magicNumber, res: result })',
+                            sessionId: 'test-session-1'
+                        }
+                    }]
+                };
+            }
+
+            if (last.role === 'tool' && step1 === 3) {
+                return {
+                    content: `Final Answer: The magic number is 42 and result is 420. JSON: ${last.content}`
+                };
+            }
+
+            return { content: "Unexpected step" };
+        }
+    });
+
+    const agent1 = new VoltClawAgent({
+        llm: llm1,
+        channel: new MockChannel(),
+        persistence: new FileStore({ path: storePath }),
+        tools
+    });
+
+    await agent1.start();
+    const result1 = await agent1.query("Load the number 42 into a variable called magicNumber using code_exec. Then multiply it by 10. Read back both.");
+    console.log("Result:", result1);
+    await agent1.stop();
+
+    // --- Test 2: Recursion from Code ---
+    console.log("\n--- Test 2: Recursion via rlm_call ---");
+
+    const llm2 = new MockLLM({
+        handler: async (messages) => {
+             const last = messages[messages.length - 1];
+             const systemMsg = messages.find(m => m.role === 'system')?.content || '';
+
+             // Handle subtask prompt
+             if (systemMsg.includes('FOCUSED sub-agent')) {
+                 return { content: "Subtask result: 13" };
+             }
+
+             if (last.role === 'user' && last.content?.includes('Fibonacci')) {
+                 return {
+                     content: "Starting recursion...",
+                     toolCalls: [{
+                         id: 'call_rec',
+                         name: 'code_exec',
+                         arguments: {
+                             // This code calls rlm_call
+                             code: `
+                                (async () => {
+                                    try {
+                                        const res = await rlm_call('Compute fib(7)', ['n']);
+                                        return "Recursion triggered. Got result: " + res;
+                                    } catch (e) {
+                                        return "Recursion failed: " + e.message;
+                                    }
+                                })()
+                             `,
+                             sessionId: 'test-rec-1',
+                             contextKeys: ['n']
+                         }
+                     }]
+                 }
+             }
+
+             if (last.role === 'tool') {
+                 return { content: "Done: " + last.content };
+             }
+
+             return { content: "Done (fallback)" };
+        }
+    });
+
+    const agent2 = new VoltClawAgent({
+        llm: llm2,
+        channel: new MockChannel(),
+        persistence: new FileStore({ path: storePath }),
+        tools
+    });
+
+    await agent2.start();
+
+    // Use a simpler mechanism to handle timeout
+    const timeout = setTimeout(() => {
+        console.error("Test 2 timed out!");
+        process.exit(1);
+    }, 10000);
+
+    try {
+        const result2 = await agent2.query("Compute 8th Fibonacci number using RLM.");
+        console.log("Result 2:", result2);
+    } catch (e) {
+        console.log("Test 2 finished with error:", e.message);
+    } finally {
+        clearTimeout(timeout);
+    }
+
+    await agent2.stop();
+    if (fs.existsSync(storePath)) fs.unlinkSync(storePath);
+    console.log("Demo complete.");
+}
+
+runDemo().catch(error => {
+    console.error("Fatal error:", error);
+    process.exit(1);
+});

--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -753,7 +753,7 @@ Parent context: ${contextSummary}${mustFinish}`;
     return response.content;
   }
 
-  private async executeTool(
+  public async executeTool(
     name: string,
     args: Record<string, unknown>,
     session: Session,
@@ -800,7 +800,7 @@ Parent context: ${contextSummary}${mustFinish}`;
         : undefined;
 
       const result = await cb.execute(
-        () => this.retrier.execute(async () => tool.execute(args)),
+        () => this.retrier.execute(async () => tool.execute(args, this, session, from)),
         fallback
       );
 

--- a/src/core/audit.ts
+++ b/src/core/audit.ts
@@ -97,7 +97,7 @@ export class FileAuditLog implements AuditLog {
 
           if (lines.length > 0) {
             // We found the last line!
-            const line = lines[lines.length - 1];
+            const line = lines[lines.length - 1]!;
             try {
                 const entry = JSON.parse(line) as AuditEntry;
                 this.lastHash = entry.hash;
@@ -108,7 +108,7 @@ export class FileAuditLog implements AuditLog {
           }
 
           // Save the first part as potential partial line for next chunk (reading backwards)
-          lastLine = lines[0];
+          lastLine = lines[0] ?? '';
           // Wait, this logic is tricky for backwards reading.
           // Let's simplify: read chunk, find last newline in it.
           // If found, take everything after it.

--- a/src/core/bootstrap.ts
+++ b/src/core/bootstrap.ts
@@ -19,6 +19,14 @@ RECURSION STRATEGY:
 3. Use 'call' to spawn a sub-agent for each sub-task.
 4. Combine the results.
 
+RLM Mode (Advanced):
+When context is large or complex:
+1. Load data into the code_exec REPL (files, HTTP, etc.).
+2. Manipulate it as normal JS objects/variables.
+3. Use rlm_call("subtask", ["key1", "key2"]) to recurse with sliced context.
+4. Synthesize final answer from REPL state.
+This gives infinite effective context with no token rot.
+
 SELF-IMPROVEMENT:
 You have access to your own source code and configuration. You can:
 1. Write new tools to the tools directory.

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -298,7 +298,7 @@ export interface Tool {
   name: string;
   description: string;
   parameters?: ToolParameters;
-  execute: (args: Record<string, unknown>) => Promise<ToolCallResult> | ToolCallResult;
+  execute: (args: Record<string, unknown>, agent?: any, session?: any, from?: string) => Promise<ToolCallResult> | ToolCallResult;
   maxDepth?: number;
   costMultiplier?: number;
   requiredRoles?: Role[];

--- a/src/tools/code_exec.ts
+++ b/src/tools/code_exec.ts
@@ -1,0 +1,84 @@
+import vm from 'vm';
+import { Tool } from '../core/types.js';
+
+const replContexts = new Map<string, vm.Context>();
+
+export const codeExecTool: Tool = {
+  name: 'code_exec',
+  description: 'Execute JavaScript in a persistent RLM sandbox. Use rlm_call() for recursion. Context survives across calls.',
+  parameters: {
+    type: 'object',
+    properties: {
+      code: { type: 'string', description: 'JS code to run' },
+      sessionId: { type: 'string', description: 'REPL session (default: task ID)' },
+      contextKeys: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Variables/files to pass to child (optional)'
+      }
+    },
+    required: ['code']
+  },
+  async execute(args: Record<string, unknown>, agent: any, session: any, from?: string) {
+    const code = args.code as string;
+    const sessionId = (args.sessionId as string) || 'default';
+    const contextKeys = (args.contextKeys as string[]) || [];
+
+    if (!replContexts.has(sessionId)) {
+      const ctx = vm.createContext({
+        // Inject VoltClaw primitives
+        read_file: (args: any) => agent.executeTool('read_file', args, session, from || 'unknown'),
+        write_file: (args: any) => agent.executeTool('write_file', args, session, from || 'unknown'),
+        http_get: (args: any) => agent.executeTool('http_get', args, session, from || 'unknown'),
+
+        // RLM recursion
+        rlm_call: async (subtask: string, keys: string[] = contextKeys) => {
+          let summary = '';
+          if (keys && keys.length > 0) {
+             const extracted: Record<string, any> = {};
+             for (const k of keys) {
+                 if (k in ctx) extracted[k] = ctx[k];
+             }
+             try {
+                summary = `Context: ${JSON.stringify(extracted)}`;
+             } catch (e) {
+                summary = `Context: [Serialization Error: ${String(e)}]`;
+             }
+          }
+
+          return await agent.executeTool('call', {
+            task: subtask,
+            summary
+          }, session, from || 'unknown');
+        },
+
+        // Power user access
+        voltclaw: agent,
+
+        // Basic console
+        console: {
+            log: (...args: any[]) => { /* suppressed */ },
+            error: (...args: any[]) => { /* suppressed */ }
+        }
+      });
+      replContexts.set(sessionId, ctx);
+    }
+
+    try {
+      const result = vm.runInContext(code, replContexts.get(sessionId)!);
+
+      let output = result;
+      if (result && typeof result.then === 'function') {
+          output = await result;
+      }
+
+      return {
+        output: output,
+        sessionId,
+        contextSize: Object.keys(replContexts.get(sessionId)!).length
+      };
+    } catch (e) {
+      return { error: (e as Error).message };
+    }
+  }
+};

--- a/src/tools/code_exec.ts
+++ b/src/tools/code_exec.ts
@@ -65,7 +65,9 @@ export const codeExecTool: Tool = {
     }
 
     try {
-      const result = vm.runInContext(code, replContexts.get(sessionId)!);
+      const result = vm.runInContext(code, replContexts.get(sessionId)!, {
+        timeout: 30000 // 30s timeout to prevent infinite loops
+      });
 
       let output = result;
       if (result && typeof result.then === 'function') {

--- a/src/tools/loader.ts
+++ b/src/tools/loader.ts
@@ -9,6 +9,7 @@ import { estimateTokensTool } from './call.js';
 import { httpGetTool, httpPostTool } from './http.js';
 import { readFileTool, writeFileTool, listFilesTool } from './files.js';
 import { restartTool } from './restart.js';
+import { codeExecTool } from './code_exec.js';
 
 async function loadUserTools(): Promise<Tool[]> {
   const tools: Tool[] = [];
@@ -47,7 +48,8 @@ export function createBuiltinTools(): Tool[] {
     readFileTool,
     writeFileTool,
     listFilesTool,
-    restartTool
+    restartTool,
+    codeExecTool
   ];
 }
 

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -3,7 +3,10 @@ import type { Tool, ToolCallResult, ToolDefinition, ToolParameters } from './typ
 export type { Tool, ToolCallResult, ToolDefinition, ToolParameters };
 
 export type ToolExecutor = (
-  args: Record<string, unknown>
+  args: Record<string, unknown>,
+  agent?: any,
+  session?: any,
+  from?: string
 ) => Promise<ToolCallResult> | ToolCallResult;
 
 interface RegisteredTool {

--- a/tests/demo_rlm.ts
+++ b/tests/demo_rlm.ts
@@ -1,0 +1,187 @@
+
+import { VoltClawAgent } from '../src/core/agent.js';
+import { MockLLM } from '../src/testing/mock-llm.js';
+import { FileStore } from '../src/memory/index.js';
+import { createAllTools } from '../src/tools/index.js';
+import { Channel, MessageHandler, Unsubscribe } from '../src/core/types.js';
+import fs from 'fs';
+import path from 'path';
+
+// --- Mocks ---
+
+class MockChannel implements Channel {
+    readonly type = 'mock';
+    readonly identity = { publicKey: 'mock-pubkey' };
+    private handlers: MessageHandler[] = [];
+
+    async start() {}
+    async stop() {}
+    async send(to: string, content: string) {
+        // Echo back to self for subtasks
+        if (to === this.identity.publicKey) {
+             const meta = { timestamp: Date.now() };
+             for (const h of this.handlers) h(to, content, meta);
+        }
+    }
+    subscribe(handler: MessageHandler): Unsubscribe {
+        this.handlers.push(handler);
+        return () => {};
+    }
+    on() {}
+}
+
+async function runDemo() {
+    console.log("=== VoltClaw RLM Demo ===");
+
+    // Setup
+    const tools = await createAllTools();
+    const storePath = path.join(process.cwd(), 'demo_data.json');
+    if (fs.existsSync(storePath)) fs.unlinkSync(storePath);
+
+    // --- Test 1: Persistence ---
+    console.log("\n--- Test 1: Persistent REPL State ---");
+
+    let step1 = 0;
+    const llm1 = new MockLLM({
+        handler: async (messages) => {
+            const last = messages[messages.length - 1];
+            // console.log(`[LLM] Step ${step1} received:`, last.role, last.content?.slice(0, 50));
+
+            if (last.role === 'user' && last.content?.includes('Load the number 42')) {
+                step1 = 1;
+                return {
+                    content: "I'll start by initializing the variable.",
+                    toolCalls: [{
+                        id: 'call1',
+                        name: 'code_exec',
+                        arguments: {
+                            code: 'var magicNumber = 42; "set";',
+                            sessionId: 'test-session-1'
+                        }
+                    }]
+                };
+            }
+
+            if (last.role === 'tool' && step1 === 1) {
+                step1 = 2;
+                return {
+                    content: "Now I will multiply it.",
+                    toolCalls: [{
+                        id: 'call2',
+                        name: 'code_exec',
+                        arguments: {
+                            code: 'var result = magicNumber * 10; result;',
+                            sessionId: 'test-session-1'
+                        }
+                    }]
+                };
+            }
+
+            if (last.role === 'tool' && step1 === 2) {
+                step1 = 3;
+                return {
+                    content: "Reading back values.",
+                    toolCalls: [{
+                        id: 'call3',
+                        name: 'code_exec',
+                        arguments: {
+                            code: '({ magic: magicNumber, res: result })',
+                            sessionId: 'test-session-1'
+                        }
+                    }]
+                };
+            }
+
+            if (last.role === 'tool' && step1 === 3) {
+                return {
+                    content: `Final Answer: The magic number is 42 and result is 420. JSON: ${last.content}`
+                };
+            }
+
+            return { content: "Unexpected step" };
+        }
+    });
+
+    const agent1 = new VoltClawAgent({
+        llm: llm1,
+        channel: new MockChannel(),
+        persistence: new FileStore({ path: storePath }),
+        tools
+    });
+
+    await agent1.start();
+    const result1 = await agent1.query("Load the number 42 into a variable called magicNumber using code_exec. Then multiply it by 10. Read back both.");
+    console.log("Result:", result1);
+    await agent1.stop();
+
+    // --- Test 2: Recursion from Code ---
+    console.log("\n--- Test 2: Recursion via rlm_call ---");
+
+    // We need to simulate the 'call' tool being triggered by code_exec
+    // We can spy on the 'call' event
+
+    const llm2 = new MockLLM({
+        handler: async (messages) => {
+             const last = messages[messages.length - 1];
+             if (last.role === 'user' && last.content?.includes('Fibonacci')) {
+                 return {
+                     content: "Starting recursion...",
+                     toolCalls: [{
+                         id: 'call_rec',
+                         name: 'code_exec',
+                         arguments: {
+                             // This code calls rlm_call
+                             code: `
+                                (async () => {
+                                    console.log("Inside JS: calling rlm_call");
+                                    // Verify rlm_call exists and calls back
+                                    const res = await rlm_call('Compute fib(7)', ['n']);
+                                    return "Recursion triggered: " + JSON.stringify(res);
+                                })()
+                             `,
+                             sessionId: 'test-rec-1',
+                             contextKeys: ['n']
+                         }
+                     }]
+                 }
+             }
+             return { content: "Done" };
+        }
+    });
+
+    const agent2 = new VoltClawAgent({
+        llm: llm2,
+        channel: new MockChannel(),
+        persistence: new FileStore({ path: storePath }),
+        tools,
+        // We can hook into onCall to verify recursion
+        hooks: {
+            onCall: async (ctx) => {
+                console.log(`[Hook] Agent triggered subtask: "${ctx.task}" at depth ${ctx.depth}`);
+            }
+        }
+    });
+
+    // We need to mock the 'call' tool execution or the subtask handling
+    // because MockChannel echoes back, the agent will try to process the subtask.
+    // The subtask processing requires LLM response.
+    // We'll simplisticly verify the *attempt* to recurse.
+
+    await agent2.start();
+
+    // Pre-inject 'n' into session context just in case (though code_exec handles missing keys gracefully-ish)
+    // Actually code_exec defines contextKeys for *extraction* from VM to pass to child.
+
+    try {
+        await agent2.query("Compute 8th Fibonacci number using RLM.");
+    } catch (e) {
+        // Use timeout to stop infinite recursion if mock channel echoes forever
+        // But for this test, we just want to see the hook log.
+        console.log("Test finished (ignoring timeouts/errors from mock loop)");
+    }
+
+    await agent2.stop();
+    if (fs.existsSync(storePath)) fs.unlinkSync(storePath);
+}
+
+runDemo().catch(console.error);


### PR DESCRIPTION
This change introduces a new `code_exec` tool that allows VoltClaw to execute JavaScript code in a persistent sandbox. This enables Recursive Language Model (RLM) capabilities where the agent can manipulate state programmatically and recurse with sliced context. 

The `code_exec` tool persists execution contexts across calls using a session ID, injects VoltClaw primitives (`read_file`, `write_file`, `http_get`) and a special `rlm_call` function into the sandbox, and supports context serialization for child agents.

Changes include:
- `src/tools/code_exec.ts`: New tool implementation.
- `src/core/types.ts`: Updated `Tool` interface to receive `agent`, `session`, `from`.
- `src/core/agent.ts`: Updated `executeTool` to be public and pass context.
- `src/tools/registry.ts`: Updated `ToolExecutor` type.
- `src/tools/loader.ts`: Registered the new tool.
- `src/core/bootstrap.ts`: Updated system prompt.
- `src/core/audit.ts`: Fix for strict null checks in build.

---
*PR created automatically by Jules for task [1192332643353580978](https://jules.google.com/task/1192332643353580978) started by @automenta*