### PR TITLE
Enhance RLM with Shared Memory and Tracing

### DIFF
--- a/src/core/agent.ts
+++ b/src/core/agent.ts
@@ -422,6 +422,10 @@ export class VoltClawAgent {
     return this.executeTool(name, args, session, this.channel.identity.publicKey);
   }
 
+  public getStore(): Store {
+    return this.store;
+  }
+
   async query(message: string, _options?: QueryOptions): Promise<string> {
     const session = this.store.get('self', true);
 

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -102,6 +102,7 @@ export interface HooksConfig {
   onReply?: (ctx: ReplyContext) => Promise<void>;
   onCall?: (ctx: CallContext) => Promise<void>;
   onError?: (ctx: ErrorContext) => Promise<void>;
+  onLog?: (ctx: LogContext) => Promise<void>;
   onToolApproval?: (tool: string, args: Record<string, unknown>) => Promise<boolean>;
   onStart?: () => Promise<void>;
   onStop?: () => Promise<void>;
@@ -139,6 +140,14 @@ export interface ErrorContext {
   timestamp: Date;
 }
 
+export interface LogContext {
+  subId: string;
+  taskId?: string;
+  message: string;
+  level: 'info' | 'error';
+  timestamp: Date;
+}
+
 export type Middleware = (
   ctx: MiddlewareContext,
   next: () => Promise<void>
@@ -171,6 +180,7 @@ export type EventMap = {
   reply: [ReplyContext];
   call: [CallContext];
   error: [ErrorContext];
+  log: [LogContext];
   start: [];
   stop: [];
 };

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -352,6 +352,10 @@ export interface MemoryQuery {
 }
 
 export interface Session {
+  id?: string;
+  parentId?: string;
+  rootId?: string;
+  sharedData?: Record<string, unknown>;
   history: ChatMessage[];
   callCount: number;
   estCostUSD: number;

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -378,6 +378,7 @@ export interface Session {
 export interface SubTaskInfo {
   createdAt: number;
   task: string;
+  schema?: Record<string, unknown> | string;
   arrived: boolean;
   result?: string;
   error?: string;

--- a/src/memory/file-store.ts
+++ b/src/memory/file-store.ts
@@ -43,7 +43,9 @@ export class FileStore implements Store {
       this.data[sessionKey] = this.createSession();
     }
     
-    return this.data[sessionKey];
+    const session = this.data[sessionKey];
+    session.id = sessionKey;
+    return session;
   }
 
   getAll(): Record<string, Session> {
@@ -75,7 +77,8 @@ export class FileStore implements Store {
       actualTokensUsed: 0,
       subTasks: {},
       depth: 0,
-      topLevelStartedAt: 0
+      topLevelStartedAt: 0,
+      sharedData: {}
     };
   }
 }

--- a/src/memory/memory-store.ts
+++ b/src/memory/memory-store.ts
@@ -25,7 +25,9 @@ export class MemoryStore implements Store {
       this.data[sessionKey] = this.createSession();
     }
     
-    return this.data[sessionKey];
+    const session = this.data[sessionKey];
+    session.id = sessionKey;
+    return session;
   }
 
   getAll(): Record<string, Session> {
@@ -51,7 +53,8 @@ export class MemoryStore implements Store {
       actualTokensUsed: 0,
       subTasks: {},
       depth: 0,
-      topLevelStartedAt: 0
+      topLevelStartedAt: 0,
+      sharedData: {}
     };
   }
 }

--- a/src/memory/sqlite.ts
+++ b/src/memory/sqlite.ts
@@ -128,10 +128,13 @@ export class SQLiteStore implements Store {
         actualTokensUsed: 0,
         subTasks: {},
         depth: 0,
-        topLevelStartedAt: 0
+        topLevelStartedAt: 0,
+        sharedData: {}
       });
     }
-    return this.cache.get(key)!;
+    const session = this.cache.get(key)!;
+    session.id = key;
+    return session;
   }
 
   getAll(): Record<string, Session> {

--- a/src/tools/call.ts
+++ b/src/tools/call.ts
@@ -4,6 +4,7 @@ export interface CallToolConfig {
   onCall: (args: {
     task: string;
     summary?: string;
+    schema?: Record<string, unknown> | string;
     depth: number;
   }) => Promise<ToolCallResult>;
   currentDepth: number;
@@ -24,6 +25,11 @@ export function createCallTool(config: CallToolConfig): Tool {
         summary: {
           type: 'string',
           description: 'Optional context summary for the child agent'
+        },
+        schema: {
+          type: 'object',
+          description: 'Optional JSON schema or description of the required output structure',
+          properties: {} // Allow any object
         }
       },
       required: ['task']
@@ -33,6 +39,7 @@ export function createCallTool(config: CallToolConfig): Tool {
     execute: async (args: Record<string, unknown>): Promise<ToolCallResult> => {
       const task = String(args['task'] ?? '');
       const summary = args['summary'] !== undefined ? String(args['summary']) : undefined;
+      const schema = args['schema'] as Record<string, unknown> | string | undefined;
 
       if (!task) {
         return { error: 'Task is required for call' };
@@ -41,6 +48,7 @@ export function createCallTool(config: CallToolConfig): Tool {
       return config.onCall({
         task,
         summary,
+        schema,
         depth: config.currentDepth + 1
       });
     }
@@ -60,7 +68,8 @@ export function createCallParallelTool(config: CallToolConfig): Tool {
             type: 'object',
             properties: {
               task: { type: 'string' },
-              summary: { type: 'string' }
+              summary: { type: 'string' },
+              schema: { type: 'object', description: 'Optional JSON schema' }
             },
             required: ['task']
           },

--- a/src/tools/code_exec.ts
+++ b/src/tools/code_exec.ts
@@ -229,7 +229,17 @@ export function createCodeExecTool(config: CodeExecConfig = {}): Tool {
         };
 
         // Define rlm_call separately to capture 'ctxObj' (which becomes 'ctx')
-        ctxObj.rlm_call = async (subtask: string, keys: string[] = contextKeys) => {
+        ctxObj.rlm_call = async (subtask: string, keysOrOptions: string[] | { contextKeys?: string[], schema?: any } = contextKeys) => {
+            let keys: string[] = [];
+            let schema: any = undefined;
+
+            if (Array.isArray(keysOrOptions)) {
+                keys = keysOrOptions;
+            } else if (typeof keysOrOptions === 'object') {
+                keys = keysOrOptions.contextKeys || [];
+                schema = keysOrOptions.schema;
+            }
+
             let summary = '';
             if (keys && keys.length > 0) {
                const extracted: Record<string, any> = {};
@@ -260,7 +270,8 @@ export function createCodeExecTool(config: CodeExecConfig = {}): Tool {
 
             const callPromise = agent.executeTool('call', {
               task: subtask,
-              summary
+              summary,
+              schema
             }, session, from || 'unknown');
 
             // Timeout logic
@@ -281,7 +292,7 @@ export function createCodeExecTool(config: CodeExecConfig = {}): Tool {
             }
         };
 
-        ctxObj.rlm_call_parallel = async (tasks: Array<{ task: string, summary?: string }>) => {
+        ctxObj.rlm_call_parallel = async (tasks: Array<{ task: string, summary?: string, schema?: any }>) => {
              const callPromise = agent.executeTool('call_parallel', {
                   tasks
              }, session, from || 'unknown');

--- a/src/tools/code_exec.ts
+++ b/src/tools/code_exec.ts
@@ -1,5 +1,6 @@
 import vm from 'vm';
 import { Tool } from '../core/types.js';
+import { createRLMGlobals } from './rlm-helpers.js';
 
 export interface CodeExecConfig {
   rlmTimeoutMs?: number;
@@ -160,216 +161,6 @@ export function createCodeExecTool(config: CodeExecConfig = {}): Tool {
           }
         };
 
-        // RLM Global: Shared Memory
-        ctxObj.rlm_shared_set = async (key: string, value: any) => {
-             const rootId = session.rootId || session.id;
-             if (!rootId) throw new Error('Root ID not found');
-
-             let store;
-             if (typeof agent.getStore === 'function') {
-                 store = agent.getStore();
-             } else {
-                 // Fallback for legacy or mock agents
-                 store = (agent as any).store || (agent as any).persistence;
-             }
-
-             if (!store) throw new Error('Store not available');
-
-             const rootSession = store.get(rootId);
-             if (!rootSession.sharedData) rootSession.sharedData = {};
-             rootSession.sharedData[key] = value;
-
-             if (store.save) await store.save();
-             return true;
-        };
-
-        ctxObj.rlm_shared_get = async (key: string) => {
-             const rootId = session.rootId || session.id;
-             if (!rootId) return undefined;
-
-             let store;
-             if (typeof agent.getStore === 'function') {
-                 store = agent.getStore();
-             } else {
-                 store = (agent as any).store || (agent as any).persistence;
-             }
-
-             if (!store) return undefined;
-
-             const rootSession = store.get(rootId);
-             return rootSession.sharedData?.[key];
-        };
-
-        ctxObj.rlm_shared_increment = async (key: string, delta: number = 1) => {
-             const rootId = session.rootId || session.id;
-             if (!rootId) throw new Error('Root ID not found');
-
-             let store;
-             if (typeof agent.getStore === 'function') {
-                 store = agent.getStore();
-             } else {
-                 store = (agent as any).store || (agent as any).persistence;
-             }
-
-             if (!store) throw new Error('Store not available');
-
-             const rootSession = store.get(rootId);
-             if (!rootSession.sharedData) rootSession.sharedData = {};
-
-             const current = Number(rootSession.sharedData[key] || 0);
-             const newVal = current + delta;
-             rootSession.sharedData[key] = newVal;
-
-             if (store.save) await store.save();
-             return newVal;
-        };
-
-        ctxObj.rlm_shared_push = async (key: string, value: any) => {
-             const rootId = session.rootId || session.id;
-             if (!rootId) throw new Error('Root ID not found');
-
-             let store;
-             if (typeof agent.getStore === 'function') {
-                 store = agent.getStore();
-             } else {
-                 store = (agent as any).store || (agent as any).persistence;
-             }
-
-             if (!store) throw new Error('Store not available');
-
-             const rootSession = store.get(rootId);
-             if (!rootSession.sharedData) rootSession.sharedData = {};
-
-             if (!Array.isArray(rootSession.sharedData[key])) {
-                 rootSession.sharedData[key] = [];
-             }
-             rootSession.sharedData[key].push(value);
-
-             if (store.save) await store.save();
-             return rootSession.sharedData[key].length;
-        };
-
-        // RLM Global: Trace
-        ctxObj.rlm_trace = async () => {
-             const trace = [];
-             let currentId = session.id;
-
-             let store;
-             if (typeof agent.getStore === 'function') {
-                 store = agent.getStore();
-             } else {
-                 store = (agent as any).store || (agent as any).persistence;
-             }
-
-             while (currentId && store) {
-                 const sess = store.get(currentId);
-                 trace.push({
-                     id: currentId,
-                     depth: sess.depth,
-                     role: sess.parentId ? 'subagent' : 'root'
-                 });
-                 currentId = sess.parentId;
-                 if (trace.length > 50) break;
-             }
-             return trace;
-        };
-
-        // RLM Global: Map
-        ctxObj.rlm_map = async (items: any[], mapper: (item: any, index: number) => any) => {
-            if (!Array.isArray(items)) throw new Error('rlm_map expects an array');
-
-            const tasks: any[] = [];
-            for (let i = 0; i < items.length; i++) {
-                const def = mapper(items[i], i);
-                if (typeof def === 'string') {
-                    tasks.push({ task: def });
-                } else if (typeof def === 'object' && def.task) {
-                    tasks.push(def);
-                } else {
-                    throw new Error(`Mapper returned invalid task definition at index ${i}`);
-                }
-            }
-
-            return ctxObj.rlm_call_parallel(tasks);
-        };
-
-        // RLM Global: Filter
-        ctxObj.rlm_filter = async (items: any[], predicate: (item: any) => any) => {
-            if (!Array.isArray(items)) throw new Error('rlm_filter expects an array');
-
-            const tasks: any[] = [];
-            for (let i = 0; i < items.length; i++) {
-                const def = predicate(items[i]);
-                const taskObj = typeof def === 'string' ? { task: def } : def;
-
-                // Enforce boolean schema
-                taskObj.schema = { type: 'boolean' };
-                // Inject item into summary if not present?
-                // The user's predicate function should handle context.
-
-                tasks.push(taskObj);
-            }
-
-            const results = await ctxObj.rlm_call_parallel(tasks);
-
-            // Filter items where result is true
-            return items.filter((_, i) => {
-                const res = results[i];
-                // rlm_call_parallel returns array of results.
-                // Each result is the output from subtask.
-                // Since we enforced boolean schema, result.result should be parsed boolean if logic works?
-                // rlm_call_parallel resolves refs.
-                // But handleSubtaskResult only parses JSON if schema was sent.
-                // Yes, we sent schema.
-                // However, rlm_call_parallel implementation:
-                // returns { status: 'completed', results: [...] }
-                // where results[i] is { status, result, subId... }
-                // and result is string.
-
-                // We need to parse the boolean from the string result.
-                try {
-                    return JSON.parse(res.result) === true;
-                } catch {
-                    return false;
-                }
-            });
-        };
-
-        // RLM Global: Reduce
-        ctxObj.rlm_reduce = async (items: any[], reducer: (acc: any, item: any) => any, initialValue: any) => {
-            if (!Array.isArray(items)) throw new Error('rlm_reduce expects an array');
-
-            let acc = initialValue;
-            for (let i = 0; i < items.length; i++) {
-                const def = reducer(acc, items[i]);
-                const task = typeof def === 'string' ? def : def.task;
-                const options = typeof def === 'object' ? def : {};
-
-                // Call single
-                const res = await ctxObj.rlm_call(task, options);
-                acc = res;
-            }
-            return acc;
-        };
-
-        ctxObj.rlm_root_id = session.rootId;
-
-        // Helper to load context by ID easily
-        ctxObj.load_context = async (id: string) => {
-             if (agent.memory) {
-                 const entries = await agent.memory.recall({ id });
-                 if (entries && entries.length > 0) {
-                     entries.sort((a, b) => {
-                         const idxA = (a.metadata as any)?.chunkIndex ?? 0;
-                         const idxB = (b.metadata as any)?.chunkIndex ?? 0;
-                         return idxA - idxB;
-                     });
-                     return entries.map(e => e.content).join('');
-                 }
-             }
-             return null;
-        };
-
         // Helper to resolve RLM references
         const resolveRLMRef = async (result: any) => {
               let output = result;
@@ -379,12 +170,12 @@ export function createCodeExecTool(config: CodeExecConfig = {}): Tool {
                    try {
                        const entries = await agent.memory.recall({ id: refId });
                        if (entries && entries.length > 0) {
-                           entries.sort((a, b) => {
+                           entries.sort((a: any, b: any) => {
                                const idxA = (a.metadata as any)?.chunkIndex ?? 0;
                                const idxB = (b.metadata as any)?.chunkIndex ?? 0;
                                return idxA - idxB;
                            });
-                           output = entries.map(e => e.content).join('');
+                           output = entries.map((e: any) => e.content).join('');
                        }
                    } catch (e) {
                        // ignore
@@ -401,101 +192,18 @@ export function createCodeExecTool(config: CodeExecConfig = {}): Tool {
               return output;
         };
 
-        // Define rlm_call separately to capture 'ctxObj' (which becomes 'ctx')
-        ctxObj.rlm_call = async (subtask: string, keysOrOptions: string[] | { contextKeys?: string[], schema?: any } = contextKeys) => {
-            let keys: string[] = [];
-            let schema: any = undefined;
-
-            if (Array.isArray(keysOrOptions)) {
-                keys = keysOrOptions;
-            } else if (typeof keysOrOptions === 'object') {
-                keys = keysOrOptions.contextKeys || [];
-                schema = keysOrOptions.schema;
-            }
-
-            let summary = '';
-            if (keys && keys.length > 0) {
-               const extracted: Record<string, any> = {};
-               const currentCtx = replContexts.get(internalSessionId);
-               if (currentCtx) {
-                   for (const k of keys) {
-                       if (k in currentCtx) extracted[k] = currentCtx[k];
-                   }
-               }
-
-               try {
-                  const contextStr = JSON.stringify(extracted);
-                  if (contextStr.length > CONTEXT_SIZE_THRESHOLD && agent.memory) {
-                    const memoryId = await agent.memory.storeMemory(
-                      contextStr,
-                      'working',
-                      ['rlm_context', `session:${internalSessionId}`],
-                      10 // High importance
-                    );
-                    summary = `RLM Context stored in memory. Use memory_recall(id='${memoryId}') to retrieve it.`;
-                  } else {
-                    summary = `Context: ${contextStr}`;
-                  }
-               } catch (e) {
-                  summary = `Context: [Serialization Error: ${String(e)}]`;
-               }
-            }
-
-            const callPromise = agent.executeTool('call', {
-              task: subtask,
-              summary,
-              schema
-            }, session, from || 'unknown');
-
-            // Timeout logic
-            let timeoutId: NodeJS.Timeout;
-            const timeoutPromise = new Promise((_, reject) => {
-               timeoutId = setTimeout(() => reject(new Error(`rlm_call timed out after ${RLM_CALL_TIMEOUT_MS}ms`)), RLM_CALL_TIMEOUT_MS);
-            });
-
-            try {
-              const result: any = await Promise.race([callPromise, timeoutPromise]);
-              clearTimeout(timeoutId!);
-
-              // Return the inner result if available (standard success), otherwise the whole object (error/mock)
-              return resolveRLMRef(result?.result ?? result);
-            } catch (e) {
-               clearTimeout(timeoutId!);
-               throw e; // Propagate error
-            }
-        };
-
-        ctxObj.rlm_call_parallel = async (tasks: Array<{ task: string, summary?: string, schema?: any }>) => {
-             const callPromise = agent.executeTool('call_parallel', {
-                  tasks
-             }, session, from || 'unknown');
-
-             // Timeout logic
-            let timeoutId: NodeJS.Timeout;
-            const timeoutPromise = new Promise((_, reject) => {
-               timeoutId = setTimeout(() => reject(new Error(`rlm_call_parallel timed out after ${RLM_CALL_TIMEOUT_MS}ms`)), RLM_CALL_TIMEOUT_MS);
-            });
-
-            try {
-               const result: any = await Promise.race([callPromise, timeoutPromise]);
-               clearTimeout(timeoutId!);
-
-               if (result.status === 'completed' && Array.isArray(result.results)) {
-                   // Resolve all results
-                   const resolved = await Promise.all(result.results.map(async (r: any) => {
-                       return {
-                           ...r,
-                           result: await resolveRLMRef(r.result)
-                       };
-                   }));
-                   return resolved;
-               }
-               return result;
-            } catch (e) {
-               clearTimeout(timeoutId!);
-               throw e;
-            }
-        };
+        // Inject RLM globals
+        const rlmGlobals = createRLMGlobals(
+            agent,
+            session,
+            internalSessionId,
+            contextKeys,
+            resolveRLMRef,
+            RLM_CALL_TIMEOUT_MS,
+            CONTEXT_SIZE_THRESHOLD,
+            replContexts
+        );
+        Object.assign(ctxObj, rlmGlobals);
 
         const ctx = vm.createContext(ctxObj);
         replContexts.set(internalSessionId, ctx);

--- a/src/tools/rlm-helpers.ts
+++ b/src/tools/rlm-helpers.ts
@@ -1,0 +1,299 @@
+
+export function createRLMGlobals(agent: any, session: any, internalSessionId: string, contextKeys: string[], resolveRLMRef: (r: any) => Promise<any>, RLM_CALL_TIMEOUT_MS: number, CONTEXT_SIZE_THRESHOLD: number, replContexts: Map<string, any>) {
+    const ctxObj: any = {};
+
+    ctxObj.rlm_shared_set = async (key: string, value: any) => {
+         const rootId = session.rootId || session.id;
+         if (!rootId) throw new Error('Root ID not found');
+
+         let store;
+         if (typeof agent.getStore === 'function') {
+             store = agent.getStore();
+         } else {
+             // Fallback for legacy or mock agents
+             store = (agent as any).store || (agent as any).persistence;
+         }
+
+         if (!store) throw new Error('Store not available');
+
+         const rootSession = store.get(rootId);
+         if (!rootSession.sharedData) rootSession.sharedData = {};
+         rootSession.sharedData[key] = value;
+
+         if (store.save) await store.save();
+         return true;
+    };
+
+    ctxObj.rlm_shared_get = async (key: string) => {
+         const rootId = session.rootId || session.id;
+         if (!rootId) return undefined;
+
+         let store;
+         if (typeof agent.getStore === 'function') {
+             store = agent.getStore();
+         } else {
+             store = (agent as any).store || (agent as any).persistence;
+         }
+
+         if (!store) return undefined;
+
+         const rootSession = store.get(rootId);
+         return rootSession.sharedData?.[key];
+    };
+
+    ctxObj.rlm_shared_increment = async (key: string, delta: number = 1) => {
+         const rootId = session.rootId || session.id;
+         if (!rootId) throw new Error('Root ID not found');
+
+         let store;
+         if (typeof agent.getStore === 'function') {
+             store = agent.getStore();
+         } else {
+             store = (agent as any).store || (agent as any).persistence;
+         }
+
+         if (!store) throw new Error('Store not available');
+
+         const rootSession = store.get(rootId);
+         if (!rootSession.sharedData) rootSession.sharedData = {};
+
+         const current = Number(rootSession.sharedData[key] || 0);
+         const newVal = current + delta;
+         rootSession.sharedData[key] = newVal;
+
+         if (store.save) await store.save();
+         return newVal;
+    };
+
+    ctxObj.rlm_shared_push = async (key: string, value: any) => {
+         const rootId = session.rootId || session.id;
+         if (!rootId) throw new Error('Root ID not found');
+
+         let store;
+         if (typeof agent.getStore === 'function') {
+             store = agent.getStore();
+         } else {
+             store = (agent as any).store || (agent as any).persistence;
+         }
+
+         if (!store) throw new Error('Store not available');
+
+         const rootSession = store.get(rootId);
+         if (!rootSession.sharedData) rootSession.sharedData = {};
+
+         if (!Array.isArray(rootSession.sharedData[key])) {
+             rootSession.sharedData[key] = [];
+         }
+         rootSession.sharedData[key].push(value);
+
+         if (store.save) await store.save();
+         return rootSession.sharedData[key].length;
+    };
+
+    // RLM Global: Trace
+    ctxObj.rlm_trace = async () => {
+         const trace = [];
+         let currentId = session.id;
+
+         let store;
+         if (typeof agent.getStore === 'function') {
+             store = agent.getStore();
+         } else {
+             store = (agent as any).store || (agent as any).persistence;
+         }
+
+         while (currentId && store) {
+             const sess = store.get(currentId);
+             trace.push({
+                 id: currentId,
+                 depth: sess.depth,
+                 role: sess.parentId ? 'subagent' : 'root'
+             });
+             currentId = sess.parentId;
+             if (trace.length > 50) break;
+         }
+         return trace;
+    };
+
+    // RLM Global: Map
+    ctxObj.rlm_map = async (items: any[], mapper: (item: any, index: number) => any) => {
+        if (!Array.isArray(items)) throw new Error('rlm_map expects an array');
+
+        const tasks: any[] = [];
+        for (let i = 0; i < items.length; i++) {
+            const def = mapper(items[i], i);
+            if (typeof def === 'string') {
+                tasks.push({ task: def });
+            } else if (typeof def === 'object' && def.task) {
+                tasks.push(def);
+            } else {
+                throw new Error(`Mapper returned invalid task definition at index ${i}`);
+            }
+        }
+
+        return ctxObj.rlm_call_parallel(tasks);
+    };
+
+    // RLM Global: Filter
+    ctxObj.rlm_filter = async (items: any[], predicate: (item: any) => any) => {
+        if (!Array.isArray(items)) throw new Error('rlm_filter expects an array');
+
+        const tasks: any[] = [];
+        for (let i = 0; i < items.length; i++) {
+            const def = predicate(items[i]);
+            const taskObj = typeof def === 'string' ? { task: def } : def;
+
+            // Enforce boolean schema
+            taskObj.schema = { type: 'boolean' };
+            // Inject item into summary if not present?
+            // The user's predicate function should handle context.
+
+            tasks.push(taskObj);
+        }
+
+        const results = await ctxObj.rlm_call_parallel(tasks);
+
+        // Filter items where result is true
+        return items.filter((_, i) => {
+            const res = results[i];
+            try {
+                return JSON.parse(res.result) === true;
+            } catch {
+                return false;
+            }
+        });
+    };
+
+    // RLM Global: Reduce
+    ctxObj.rlm_reduce = async (items: any[], reducer: (acc: any, item: any) => any, initialValue: any) => {
+        if (!Array.isArray(items)) throw new Error('rlm_reduce expects an array');
+
+        let acc = initialValue;
+        for (let i = 0; i < items.length; i++) {
+            const def = reducer(acc, items[i]);
+            const task = typeof def === 'string' ? def : def.task;
+            const options = typeof def === 'object' ? def : {};
+
+            // Call single
+            const res = await ctxObj.rlm_call(task, options);
+            acc = res;
+        }
+        return acc;
+    };
+
+    ctxObj.rlm_root_id = session.rootId;
+
+    // Helper to load context by ID easily
+    ctxObj.load_context = async (id: string) => {
+         if (agent.memory) {
+             const entries = await agent.memory.recall({ id });
+             if (entries && entries.length > 0) {
+                 entries.sort((a: any, b: any) => {
+                     const idxA = (a.metadata as any)?.chunkIndex ?? 0;
+                     const idxB = (b.metadata as any)?.chunkIndex ?? 0;
+                     return idxA - idxB;
+                 });
+                 return entries.map((e: any) => e.content).join('');
+             }
+         }
+         return null;
+    };
+
+    // Define rlm_call separately to capture 'ctxObj' (which becomes 'ctx')
+    ctxObj.rlm_call = async (subtask: string, keysOrOptions: string[] | { contextKeys?: string[], schema?: any } = contextKeys) => {
+        let keys: string[] = [];
+        let schema: any = undefined;
+
+        if (Array.isArray(keysOrOptions)) {
+            keys = keysOrOptions;
+        } else if (typeof keysOrOptions === 'object') {
+            keys = keysOrOptions.contextKeys || [];
+            schema = keysOrOptions.schema;
+        }
+
+        let summary = '';
+        if (keys && keys.length > 0) {
+           const extracted: Record<string, any> = {};
+           const currentCtx = replContexts.get(internalSessionId);
+           if (currentCtx) {
+               for (const k of keys) {
+                   if (k in currentCtx) extracted[k] = currentCtx[k];
+               }
+           }
+
+           try {
+              const contextStr = JSON.stringify(extracted);
+              if (contextStr.length > CONTEXT_SIZE_THRESHOLD && agent.memory) {
+                const memoryId = await agent.memory.storeMemory(
+                  contextStr,
+                  'working',
+                  ['rlm_context', `session:${internalSessionId}`],
+                  10 // High importance
+                );
+                summary = `RLM Context stored in memory. Use memory_recall(id='${memoryId}') to retrieve it.`;
+              } else {
+                summary = `Context: ${contextStr}`;
+              }
+           } catch (e) {
+              summary = `Context: [Serialization Error: ${String(e)}]`;
+           }
+        }
+
+        const callPromise = agent.executeTool('call', {
+          task: subtask,
+          summary,
+          schema
+        }, session, 'unknown');
+
+        // Timeout logic
+        let timeoutId: NodeJS.Timeout;
+        const timeoutPromise = new Promise((_, reject) => {
+           timeoutId = setTimeout(() => reject(new Error(`rlm_call timed out after ${RLM_CALL_TIMEOUT_MS}ms`)), RLM_CALL_TIMEOUT_MS);
+        });
+
+        try {
+          const result: any = await Promise.race([callPromise, timeoutPromise]);
+          clearTimeout(timeoutId!);
+
+          // Return the inner result if available (standard success), otherwise the whole object (error/mock)
+          return resolveRLMRef(result?.result ?? result);
+        } catch (e) {
+           clearTimeout(timeoutId!);
+           throw e; // Propagate error
+        }
+    };
+
+    ctxObj.rlm_call_parallel = async (tasks: Array<{ task: string, summary?: string, schema?: any }>) => {
+         const callPromise = agent.executeTool('call_parallel', {
+              tasks
+         }, session, 'unknown');
+
+         // Timeout logic
+        let timeoutId: NodeJS.Timeout;
+        const timeoutPromise = new Promise((_, reject) => {
+           timeoutId = setTimeout(() => reject(new Error(`rlm_call_parallel timed out after ${RLM_CALL_TIMEOUT_MS}ms`)), RLM_CALL_TIMEOUT_MS);
+        });
+
+        try {
+           const result: any = await Promise.race([callPromise, timeoutPromise]);
+           clearTimeout(timeoutId!);
+
+           if (result.status === 'completed' && Array.isArray(result.results)) {
+               // Resolve all results
+               const resolved = await Promise.all(result.results.map(async (r: any) => {
+                   return {
+                       ...r,
+                       result: await resolveRLMRef(r.result)
+                   };
+               }));
+               return resolved;
+           }
+           return result;
+        } catch (e) {
+           clearTimeout(timeoutId!);
+           throw e;
+        }
+    };
+
+    return ctxObj;
+}


### PR DESCRIPTION
This PR enhances the usability of Recursive Language Models (RLM) in VoltClawAgent.
It introduces mechanisms for sub-agents to share state and inspect their execution context within the recursion tree.

Key Changes:
1.  **Shared Memory**: Added `rlm_shared_set(key, value)` and `rlm_shared_get(key)` globals to `code_exec` sandbox. These allow sub-agents to read/write data to the root session's `sharedData` store, enabling side-channel communication and global state management across the recursion tree.
2.  **Call Tracing**: Added `rlm_trace()` global to `code_exec` sandbox. It returns the current call stack (chain of parent sessions) to help agents understand their role and depth.
3.  **Session Metadata**: Updated `Session` interface and all store implementations to track `id`, `rootId`, `parentId`, and `sharedData`.
4.  **Scoped REPL**: `code_exec` now uses a composite key (`session.id` + `userSessionId`) for REPL contexts. This prevents variable collision when multiple sub-agents run in parallel or recursively within the same process.
5.  **Agent Logic Updates**: Updated `VoltClawAgent`'s `handleTopLevel`, `handleSubtask`, `executeCall`, and `query` methods to correctly initialize and propagate the new session metadata.

Verification:
- Added "Test 3: Shared Memory & Trace" to `scripts/rlm_demonstration.ts`, verifying that a sub-agent can read a value set by root, trace its ancestry, and update the shared value.
- Ran `pnpm test` to ensure no regressions in existing functionality.

---
*PR created automatically by Jules for task [7278747232517157271](https://jules.google.com/task/7278747232517157271) started by @automenta*